### PR TITLE
SC-59615-chasehippen

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "handler_lambda" {
   role          = aws_iam_role.event_handler_lambda_iam_role.arn
   handler       = var.handler_entrypoint
 
-  source_code_hash = filebase64sha256("${path.module}/tmp/handler_function.zip")
+  source_code_hash = data.archive_file.handler_function_zip.output_base64sha256
 
   runtime                        = var.handler_runtime
   reserved_concurrent_executions = 0


### PR DESCRIPTION
updating source_code_hash to reference data archive hash directly rather than trying to zip output