### PR TITLE
adding dummy trigger to force archiving files during applies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,16 @@
+# Resource for archive_file to depend on to force archiving during applies
+resource null_resource trigger {
+  triggers = {
+    timestamp = timestamp()
+  }
+}
+
 data "archive_file" "handler_function_zip" {
   type        = "zip"
   source_dir  = var.handler_path
   output_path = "${path.root}/handler_function.zip"
+
+  depends_on = [resource.null_resource.trigger]
 }
 
 resource "aws_iam_role" "event_handler_lambda_iam_role" {


### PR DESCRIPTION
Github CI runs the plan and apply stages are run in separate containers, and the archiving step is executed in the plan stage.

This workaround creates a null_resource trigger  and forces the archive_file to depend on it and to be executed during the apply