### PR TITLE
add expires-on tag to queue and function templates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ resource "aws_lambda_function" "handler_lambda" {
 
   tags = {
     owner      = var.owner
-    expires_at = "never"
+    expires-on = "never"
     managed-by = "terraform"
   }
 }
@@ -114,7 +114,7 @@ resource "aws_sqs_queue" "event_sqs_queue" {
 
   tags = {
     owner      = var.owner
-    expires_at = "never"
+    expires-on = "never"
     managed-by = "terraform"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,7 @@ resource "aws_lambda_function" "handler_lambda" {
 
   tags = {
     owner      = var.owner
+    expires_at = "never"
     managed-by = "terraform"
   }
 }
@@ -113,6 +114,7 @@ resource "aws_sqs_queue" "event_sqs_queue" {
 
   tags = {
     owner      = var.owner
+    expires_at = "never"
     managed-by = "terraform"
   }
 }


### PR DESCRIPTION
* Adds `expires-on: "never"` to upstream definitions for SQS and Lambda functions
* Actual changes would be observed in downstream usages of this in `cloud-custodian` and `replicated-sysdig` 